### PR TITLE
Dotnetcore

### DIFF
--- a/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
+++ b/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.1;net45</TargetFrameworks>
     <Version>1.7.0</Version>
-    <Authors>Stefan Negritoiu (FreeBusy)</Authors>
+    <Authors>Stefan Negritoiu (FreeBusy) and contributors</Authors>
     <Owners>Stefan Negritoiu (FreeBusy)</Owners>
     <Product>AlexaSkillsKit</Product>
     <PackageId>AlexaSkillsKit.Net</PackageId>
@@ -18,11 +18,12 @@
     <PackageIconUrl>https://developer.amazon.com/public/binaries/content/gallery/developerportalpublic/solutions/alexa/dp_image_kit_02.png</PackageIconUrl>
     <PackageTags>amazon echo alexa speechlet</PackageTags>
     <PackageReleaseNotes>
-1.3.0: Incorporated Sept 2015 ASK update for account linking and access tokens
-1.4.0: Ability to override request validation policy and support for SSML output speech type
-1.5.0: Fully implement certificate verification requirement and support for Standard cards
-1.5.1: bug fix in certificate verification
-1.7.0: migration to netstandard1.1 (supports .net 4.5+, .net core 1.x and .net core 2.x)
+      1.3.0: Incorporated Sept 2015 ASK update for account linking and access tokens
+      1.4.0: Ability to override request validation policy and support for SSML output speech type
+      1.5.0: Fully implement certificate verification requirement and support for Standard cards
+      1.5.1: bug fix in certificate verification
+      1.6.0: migration to netstandard1.1 (supports .net 4.5+ and .net core 1.0+)
+      1.7.0: migration to netstandard2.0 (supports .net 4.5+, .net core 1.0+ and .net core 2.0+)
     </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.1'">

--- a/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
+++ b/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
-    <Version>1.6.0</Version>
+    <TargetFrameworks>netstandard2.0;netstandard1.1;net45</TargetFrameworks>
+    <Version>1.7.0</Version>
     <Authors>Stefan Negritoiu (FreeBusy)</Authors>
     <Owners>Stefan Negritoiu (FreeBusy)</Owners>
     <Product>AlexaSkillsKit</Product>
     <PackageId>AlexaSkillsKit.Net</PackageId>
     <Title>AlexaSkillsKit.Net</Title>
-    <AssemblyVersion>1.5.0</AssemblyVersion>
-    <FileVersion>1.5.0</FileVersion>
+    <AssemblyVersion>1.7.0</AssemblyVersion>
+    <FileVersion>1.7.0</FileVersion>
     <Description>
 .NET library that simplifies Alexa skills development; same object model as Amazon's AlexaSkillsKit for Java
     </Description>
@@ -22,13 +22,34 @@
 1.4.0: Ability to override request validation policy and support for SSML output speech type
 1.5.0: Fully implement certificate verification requirement and support for Standard cards
 1.5.1: bug fix in certificate verification
-1.6.0: migration to netstandard1.1 (supports .net 4.5+ and .net core 1.0+)
+1.7.0: migration to netstandard1.1 (supports .net 4.5+, .net core 1.x and .net core 2.x)
     </PackageReleaseNotes>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.1'">
+    <DefineConstants>$(DefineConstants);NETCORE;NETSTD11</DefineConstants>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <DefineConstants>$(DefineConstants);NETCORE;NETSTD20</DefineConstants>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
+    <DefineConstants>NET45</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.1" />
+
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
+++ b/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
@@ -28,12 +28,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTD11</DefineConstants>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTD20</DefineConstants>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">

--- a/AlexaSkillsKit.SampleCore/AlexaSkillsKit.SampleCore.csproj
+++ b/AlexaSkillsKit.SampleCore/AlexaSkillsKit.SampleCore.csproj
@@ -13,4 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="AlexaSkillsKit.Net" Version="1.6.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AlexaSkillsKit.Lib\AlexaSkillsKit.Lib.csproj" />
+  </ItemGroup>
 </Project>

--- a/AlexaSkillsKit.SampleCore/README.TXT
+++ b/AlexaSkillsKit.SampleCore/README.TXT
@@ -1,0 +1,4 @@
+﻿
+#
+# Sample .Net Core 1.1 WebAPI Project
+#

--- a/AlexaSkillsKit.SampleCore2/AlexaSkillsKit.SampleCore2.csproj
+++ b/AlexaSkillsKit.SampleCore2/AlexaSkillsKit.SampleCore2.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AlexaSkillsKit.Lib\AlexaSkillsKit.Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AlexaSkillsKit.SampleCore2/Controllers/ValuesController.cs
+++ b/AlexaSkillsKit.SampleCore2/Controllers/ValuesController.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AlexaSkillsKit.SampleCore2.Controllers
+{
+    [Route("api/[controller]")]
+    public class ValuesController : Controller
+    {
+        // GET api/values
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        [HttpPost]
+        public void Post([FromBody]string value)
+        {
+        }
+
+        // PUT api/values/5
+        [HttpPut("{id}")]
+        public void Put(int id, [FromBody]string value)
+        {
+        }
+
+        // DELETE api/values/5
+        [HttpDelete("{id}")]
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/AlexaSkillsKit.SampleCore2/Program.cs
+++ b/AlexaSkillsKit.SampleCore2/Program.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AlexaSkillsKit.SampleCore2
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseKestrel()    
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/AlexaSkillsKit.SampleCore2/Properties/launchSettings.json
+++ b/AlexaSkillsKit.SampleCore2/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55038/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "AlexaSkillsKit.SampleCore2": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:55039/"
+    }
+  }
+}

--- a/AlexaSkillsKit.SampleCore2/README.TXT
+++ b/AlexaSkillsKit.SampleCore2/README.TXT
@@ -1,0 +1,4 @@
+﻿
+#
+# Sample .Net Core 2.0 WebAPI Project
+#

--- a/AlexaSkillsKit.SampleCore2/Startup.cs
+++ b/AlexaSkillsKit.SampleCore2/Startup.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace AlexaSkillsKit.SampleCore2
+{
+    public class Startup
+    {
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+            Configuration = builder.Build();
+        }
+
+        public IConfigurationRoot Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Add framework services.
+            services.AddMvc().AddWebApiConventions();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
+            loggerFactory.AddDebug();
+
+            app.UseMvc();
+        }
+    }
+}

--- a/AlexaSkillsKit.SampleCore2/appsettings.Development.json
+++ b/AlexaSkillsKit.SampleCore2/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/AlexaSkillsKit.SampleCore2/appsettings.json
+++ b/AlexaSkillsKit.SampleCore2/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}

--- a/AlexaSkillsKit.sln
+++ b/AlexaSkillsKit.sln
@@ -1,20 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlexaSkillsKit.Lib", "AlexaSkillsKit.Lib\AlexaSkillsKit.Lib.csproj", "{0EC882A8-AACA-4BD5-B449-72F20FDB8586}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlexaSkillsKit.Lib", "AlexaSkillsKit.Lib\AlexaSkillsKit.Lib.csproj", "{0EC882A8-AACA-4BD5-B449-72F20FDB8586}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlexaSkillsKit.Sample", "AlexaSkillsKit.Sample\AlexaSkillsKit.Sample.csproj", "{9FDEF793-5832-4D37-B0D5-62C55AB1C12E}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{D35AD75F-7926-41CB-8C8D-BB36370F3E76}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlexaSkillsKit.Tests", "AlexaSkillsKit.Tests\AlexaSkillsKit.Tests.csproj", "{D0125A95-FD63-4A33-9220-206D4A1A14F0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Packaging", "Packaging", "{0F14DFB6-D386-42C5-AF2A-6E33E4742F2F}"
 	ProjectSection(SolutionItems) = preProject
-		.nuget\AlexaSkillsKit.Lib.nuspec = .nuget\AlexaSkillsKit.Lib.nuspec
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.targets = .nuget\NuGet.targets
+		createPackages.cmd = createPackages.cmd
+		createPackages.ps1 = createPackages.ps1
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlexaSkillsKit.Tests", "AlexaSkillsKit.Tests\AlexaSkillsKit.Tests.csproj", "{D0125A95-FD63-4A33-9220-206D4A1A14F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlexaSkillsKit.SampleCore", "AlexaSkillsKit.SampleCore\AlexaSkillsKit.SampleCore.csproj", "{877D93F7-DD52-406B-91C2-8DF9C5F9257D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlexaSkillsKit.SampleCore2", "AlexaSkillsKit.SampleCore2\AlexaSkillsKit.SampleCore2.csproj", "{9F529E87-083B-4457-9449-7D50E00DC077}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,8 +37,19 @@ Global
 		{D0125A95-FD63-4A33-9220-206D4A1A14F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0125A95-FD63-4A33-9220-206D4A1A14F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0125A95-FD63-4A33-9220-206D4A1A14F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{877D93F7-DD52-406B-91C2-8DF9C5F9257D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{877D93F7-DD52-406B-91C2-8DF9C5F9257D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{877D93F7-DD52-406B-91C2-8DF9C5F9257D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{877D93F7-DD52-406B-91C2-8DF9C5F9257D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F529E87-083B-4457-9449-7D50E00DC077}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F529E87-083B-4457-9449-7D50E00DC077}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F529E87-083B-4457-9449-7D50E00DC077}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F529E87-083B-4457-9449-7D50E00DC077}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C4E53B59-D9EB-4215-9B38-FAB98A2AA9A4}
 	EndGlobalSection
 EndGlobal

--- a/createPackages.cmd
+++ b/createPackages.cmd
@@ -1,0 +1,2 @@
+
+powershell.exe -ExecutionPolicy ByPass -file createPackages.ps1

--- a/createPackages.ps1
+++ b/createPackages.ps1
@@ -1,0 +1,8 @@
+# Author: Klaus Comelli
+# Manually build multi-target packages using dotnet pack
+
+# Building DEBUG packages (incl. build action) 
+dotnet pack .\AlexaSkillsKit.Lib -c Debug -o .\bin\Packages\Debug --version-suffix "debug"
+
+# Building Release packages (incl. build action) 
+dotnet pack .\AlexaSkillsKit.Lib -c Release -o .\bin\Packages\Release


### PR DESCRIPTION
Changed AlexaSkillsKit.Lib project to multi framework targeting library supporting .Net Framework 4.5+, .Net Standard 1.1 and .Net Standard 2.0.
Added a simple batch file and powershell to create a single multi framework targeting nuget package.
Set version to 1.7.0 (package and assembly)

Info: If you run the createPackages.cmd the NuGet package for Debug and Release configuration can be found in .\AlexaSkillsKit.Lib\bin\Packages.

I've configured some constants which may be used if you have to add some code which is only valid for a special target framework. Introduced constants are:
#NET45 ... for .Net Framework 4.5+
#NETCORE ... for .Net Core targeting (active for .Net 1.1 and 2.0)
#NETSTD11 ... for .Net Standard 1.1 only
#NETSTD20 ... for .Net  Standard 2.0 only

If you edit a source file (e.g. Sdk.cs) you can easily switch the target framework using the drop--down box in the upper-left corner of your code editor window (next to the class selection drop down).

PS: I did not test it because I'm preparing an alexa backend for .net core 2.0 which is currently not active. I just did some configuration because I have experiences in creating multi framework targeting!